### PR TITLE
fix(eslint): actualizar configuración a module y activar no-unused-vars

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,8 @@ import eslint from '@eslint/js';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
 export default tseslint.config(
   {
@@ -17,10 +19,10 @@ export default tseslint.config(
         ...globals.node,
         ...globals.jest,
       },
-      sourceType: 'commonjs',
+      sourceType: 'module',
       parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        project: './tsconfig.json',
+        tsconfigRootDir: dirname(fileURLToPath(import.meta.url)),
       },
     },
   },
@@ -28,7 +30,8 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
     },
   },
 );


### PR DESCRIPTION
- Cambiado sourceType a module para alinear con tsconfig.json

- Agregada regla @typescript-eslint/no-unused-vars como 'warn'