### PR TITLE
feat(address): agregar soporte de dirección por defecto

### DIFF
--- a/prisma/migrations/20250828000134_add_isdefault_to_address/migration.sql
+++ b/prisma/migrations/20250828000134_add_isdefault_to_address/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Address" ADD COLUMN     "isDefault" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Address {
   zipcode   String?
   latitude  Float
   longitude Float
+  isDefault Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/modules/address/controllers/address.controller.ts
+++ b/src/modules/address/controllers/address.controller.ts
@@ -16,7 +16,6 @@ import { UpdateAddressDto } from '../dto/update-address.dto';
 import { JwtAuthGuard } from 'src/modules/auth/jwt/jwt.guard';
 import type { AuthRequest } from 'src/types/express';
 
-
 @Controller('addresses')
 @UseGuards(JwtAuthGuard)
 export class AddressController {
@@ -35,14 +34,15 @@ export class AddressController {
 
   @Get(':id')
   async findOne(
-    @Param('id',ParseIntPipe) id:number,
-     @Req() req: AuthRequest) {
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthRequest,
+  ) {
     return this.addressService.getAddressById(id, req.user.id);
   }
 
   @Patch(':id')
   async update(
-    @Param('id',ParseIntPipe) id: number,
+    @Param('id', ParseIntPipe) id: number,
     @Body() dto: Partial<UpdateAddressDto>,
     @Req() req: AuthRequest,
   ) {
@@ -50,9 +50,15 @@ export class AddressController {
   }
 
   @Delete(':id')
-  async delete(
-  @Param('id',ParseIntPipe) id: number,
-  @Req() req: AuthRequest) {
+  async delete(@Param('id', ParseIntPipe) id: number, @Req() req: AuthRequest) {
     return this.addressService.deleteAddress(id, req.user.id);
+  }
+
+  @Patch(':id/default')
+  async setDefault(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthRequest,
+  ) {
+    return this.addressService.setDefaultAddress(id, req.user.id);
   }
 }

--- a/src/modules/address/dto/create-address.dto.ts
+++ b/src/modules/address/dto/create-address.dto.ts
@@ -1,4 +1,4 @@
-import { IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class CreateAddressDto {
   @IsString()
@@ -21,4 +21,8 @@ export class CreateAddressDto {
   
   @IsNumber()
   longitude: number;
+
+  @IsOptional()
+  @IsBoolean()
+  isDefault: boolean;
 }

--- a/src/modules/address/services/address.service.ts
+++ b/src/modules/address/services/address.service.ts
@@ -6,6 +6,8 @@ import { CacheService } from './cache.service';
 import { UpdateAddressDto } from '../dto/update-address.dto';
 import { normalizeCoordinates } from '../utils/coords.helper';
 import {
+  shouldBeDefault,
+  validateAddressOwnership,
   validateCreateAddress,
   validateUpdateAddress,
 } from '../utils/address.validator';
@@ -19,6 +21,8 @@ export class AddressService {
   ) {}
 
   async createAddress(dto: CreateAddressDto, userId: number) {
+    const isDefault = await shouldBeDefault(userId, this.prisma);
+
     const coords = await validateCreateAddress(
       dto,
       userId,
@@ -32,6 +36,7 @@ export class AddressService {
         ...dto,
         ...coords,
         userId,
+        isDefault,
       },
     });
   }
@@ -89,5 +94,26 @@ export class AddressService {
     }
 
     return { message: 'Dirección eliminada correctamente' };
+  }
+
+  async setDefaultAddress(addressId: number, userId: number) {
+    const address = await validateAddressOwnership(
+      addressId,
+      userId,
+      this.prisma,
+    );
+
+    await this.prisma.$transaction([
+      this.prisma.address.updateMany({
+        where: { userId },
+        data: { isDefault: false },
+      }),
+      this.prisma.address.update({
+        where: { id: address.id },
+        data: { isDefault: true },
+      }),
+    ]);
+
+    return { message: 'Dirección por defecto actualizada correctamente' };
   }
 }

--- a/src/modules/address/utils/address.validator.ts
+++ b/src/modules/address/utils/address.validator.ts
@@ -120,3 +120,22 @@ export async function validateUpdateAddress(
 
   return coords;
 }
+
+// --- Validar si la dirección debe ser default ---
+export async function shouldBeDefault(userId: number, prisma: PrismaService) {
+  const count = await prisma.address.count({ where: { userId } });
+  return count === 0; 
+}
+
+// Validar que la dirección exista y pertenezca al usuario
+export async function validateAddressOwnership(
+  addressId: number,
+  userId: number,
+  prisma: PrismaService,
+) {
+  const address = await prisma.address.findUnique({ where: { id: addressId } });
+  if (!address || address.userId !== userId) {
+    throw new BadRequestException('No puedes modificar esta dirección');
+  }
+  return address;
+}


### PR DESCRIPTION
- Agregar campo isDefault en modelo Address y DTO de creación

- Implementar lógica para asignar la primera dirección como default automáticamente

- Añadir método setDefaultAddress en el servicio y endpoint correspondiente en el controlador

- Mover validaciones de negocio a address.validator.ts