### PR TITLE
refactor(user): centralizar roles y validaciones de usuario

### DIFF
--- a/prisma/migrations/20250828203627_alter_role_to_string/migration.sql
+++ b/prisma/migrations/20250828203627_alter_role_to_string/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `role` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."User" DROP COLUMN "role",
+ADD COLUMN     "role" TEXT NOT NULL DEFAULT 'CONSUMER';
+
+-- DropEnum
+DROP TYPE "public"."Role";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ model User {
   email     String   @unique
   password  String
   phone     String   @unique
-  role      Role     @default(CONSUMER)
+  role      String   @default("CONSUMER")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -37,10 +37,4 @@ model Address {
 
   //Relaciones
   user User @relation(fields: [userId], references: [id])
-}
-
-enum Role {
-  CONSUMER
-  ADMIN
-  MODERATOR
 }

--- a/src/common/constants/role.enum.ts
+++ b/src/common/constants/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  USER = 'USER',
+  ADMIN = 'ADMIN',
+  EDITOR = 'EDITOR',
+}

--- a/src/modules/auth/decorators/role.decorators.ts
+++ b/src/modules/auth/decorators/role.decorators.ts
@@ -1,6 +1,7 @@
 // src/modules/auth/decorators/roles.decorator.ts
 import { SetMetadata } from '@nestjs/common';
-import { Role } from '@prisma/client';
+//import { Role } from '@prisma/client';
 import { ROLES_KEY } from '../guards/roles.guard';
+import { Role } from 'src/common/constants/role.enum';
 
 export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/modules/auth/guards/roles.guard.ts
+++ b/src/modules/auth/guards/roles.guard.ts
@@ -1,8 +1,9 @@
 // src/modules/auth/guards/roles.guard.ts
 import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { Role } from 'src/common/constants/role.enum';
 import { JwtPayload } from 'src/types/express';
-import { Role } from '@prisma/client';
+//import { Role } from '@prisma/client';
 
 export const ROLES_KEY = 'roles';
 

--- a/src/modules/user/controllers/user.controller.ts
+++ b/src/modules/user/controllers/user.controller.ts
@@ -15,7 +15,9 @@ import { CreateUserDto } from '../dto/create-user.dto';
 import { RolesGuard } from 'src/modules/auth/guards/roles.guard';
 import { JwtAuthGuard } from 'src/modules/auth/jwt/jwt.guard';
 import { Roles } from 'src/modules/auth/decorators/role.decorators';
-import { Role } from '@prisma/client';
+
+import { UpdateUserDto } from '../dto/update-user.dto';
+import { Role } from 'src/common/constants/role.enum';
 
 @Controller('users')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -48,7 +50,7 @@ export class UserController {
   @Patch(':id')
   async update(
     @Param('id', ParseIntPipe) id: number,
-    @Body() dto: Partial<CreateUserDto>,
+    @Body() dto: UpdateUserDto,
   ) {
     return this.userService.updateUser(id, dto);
   }

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -1,4 +1,3 @@
-//import { Role } from '@prisma/client';
 import {
   IsBoolean,
   IsEmail,
@@ -7,24 +6,30 @@ import {
   IsString,
 } from 'class-validator';
 import { Role } from 'src/common/constants/role.enum';
+//import { Role } from '@prisma/client';
 
-export class CreateUserDto {
+export class UpdateUserDto {
+  @IsOptional()
   @IsString()
-  name: string;
+  name?: string;
 
+  @IsOptional()
   @IsEmail()
-  email: string;
+  email?: string;
 
+  @IsOptional()
   @IsString()
-  password: string;
+  password?: string;
 
+  @IsOptional()
   @IsEnum(Role)
-  role: Role;
+  role?: Role;
 
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
 
+  @IsOptional()
   @IsString()
-  phone: string;
+  phone?: string;
 }

--- a/src/modules/user/services/user.service.ts
+++ b/src/modules/user/services/user.service.ts
@@ -3,17 +3,17 @@ import { CreateUserDto } from '../dto/create-user.dto';
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { hash } from 'bcrypt';
 import {
-  validateEmailUpdate,
-  validateUserEmailUnique,
+  validateEmailUnique,
   validateUserExists,
 } from '../utils/user.validator';
+import { UpdateUserDto } from '../dto/update-user.dto';
 
 @Injectable()
 export class UserService {
   constructor(private readonly prisma: PrismaService) {}
 
   async createUser(dto: CreateUserDto) {
-    await validateUserEmailUnique(dto.email, this.prisma);
+    await validateEmailUnique(dto.email, this.prisma);
     const hashedPassword = await hash(dto.password, 10);
 
     const user = await this.prisma.user.create({
@@ -36,10 +36,10 @@ export class UserService {
     return validateUserExists(id, this.prisma);
   }
 
-  async updateUser(id: number, dto: Partial<CreateUserDto>) {
+  async updateUser(id: number, dto: UpdateUserDto) {
     await validateUserExists(id, this.prisma);
     if (dto.email) {
-      await validateEmailUpdate(id, dto.email, this.prisma);
+      await validateEmailUnique(dto.email, this.prisma, id);
     }
 
     const updatedUser = await this.prisma.user.update({
@@ -56,19 +56,19 @@ export class UserService {
     return this.prisma.user.delete({ where: { id } });
   }
 
+  async findUserByPhone(phone: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { phone },
+      include: { addresses: true },
+    });
 
-async findUserByPhone(phone: string) {
-  const user = await this.prisma.user.findUnique({
-    where: { phone },
-    include: { addresses: true },
-  });
+    if (!user) {
+      throw new NotFoundException(
+        `No existe un usuario con el teléfono ${phone}`,
+      );
+    }
 
-  if (!user) {
-    throw new NotFoundException(`No existe un usuario con el teléfono ${phone}`);
+    const { password, ...safeUser } = user;
+    return safeUser;
   }
-
-  const { password, ...safeUser } = user;
-  return safeUser;
-}
-
 }

--- a/src/modules/user/utils/user.validator.ts
+++ b/src/modules/user/utils/user.validator.ts
@@ -3,23 +3,21 @@ import { PrismaService } from 'src/prisma/prisma.service';
 
 /**
  * Valida que un email no esté siendo usado por otro usuario distinto
- * @param id - ID del usuario que se está actualizando
  * @param email - Email que se quiere asignar
  * @param prisma - Instancia de PrismaService
+ * @param id? - (Opcional) ID del usuario actual para excluirlo de la validación.
  * @throws BadRequestException si el email ya pertenece a otro usuario
  */
-export const validateEmailUpdate = async (
-  id: number,
+export const validateEmailUnique = async (
   email: string,
   prisma: PrismaService,
+  id?: number,
 ) => {
   const exists = await prisma.user.findUnique({ where: { email } });
 
   // Si el email ya existe en otro usuario distinto
   if (exists && exists.id !== id) {
-    throw new BadRequestException(
-      'The email is already in use by another user',
-    );
+    throw new BadRequestException('The email is already in use by another user');
   }
 };
 
@@ -40,16 +38,4 @@ export const validateUserExists = async (id: number, prisma: PrismaService) => {
   return user;
 };
 
-/**
- * Valida que un email no esté siendo usado por otro usuario al crear un nuevo usuario.
- * @param email - Email que se quiere asignar al nuevo usuario
- * @param prisma - Instancia de PrismaService
- * @throws BadRequestException si el email ya está registrado
- */
-export const validateUserEmailUnique = async (
-  email: string,
-  prisma: PrismaService,
-) => {
-  const exists = await prisma.user.findUnique({ where: { email } });
-  if (exists) throw new BadRequestException('Email already in use');
-};
+


### PR DESCRIPTION
Se modifica el modelo de usuario para usar un enum centralizado en el código y se refactorizan las validaciones de email para ser reutilizables.

- Se crea el DTO de actualización para el módulo de usuario.

- Se centraliza la definición del enum 'Role' en src/common.

- Se migra el esquema de Prisma para que el rol sea de tipo 'String'.

- Se refactorizan las funciones de validación para ser más reutilizables.